### PR TITLE
add image directive for redis worker

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -43,7 +43,7 @@ services:
       - redis-data:/data
 
   redis-worker:
-    image: medicmobile/cht-sync-redis-worker:latest
+    image: dockermedic/cht-sync-redis-worker:latest
     build: ./redis-worker/
     environment:
       - REDIS_HOST=${REDIS_HOST}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -43,6 +43,7 @@ services:
       - redis-data:/data
 
   redis-worker:
+    image: medicmobile/cht-sync-redis-worker:latest
     build: ./redis-worker/
     environment:
       - REDIS_HOST=${REDIS_HOST}


### PR DESCRIPTION
@njuguna-n quick one; add an image directive so that the github build action pushes the redis worker image to the repo after commit to main.
It's is awkward to use locally built images with helm/kubernetes