### PR TITLE
feat(#78): full refresh on changed objects, only incremental runs con…

### DIFF
--- a/dbt/Dockerfile
+++ b/dbt/Dockerfile
@@ -27,4 +27,6 @@ COPY dbt-run.py dbt-run.py
 COPY .dbt .dbt
 COPY dbt_project.yml dbt_project.yml
 
+RUN mkdir old_manifest
+
 CMD ["python3", "/dbt/dbt-run.py"]

--- a/dbt/dbt-run.py
+++ b/dbt/dbt-run.py
@@ -78,9 +78,9 @@ with connection() as conn:
         manifest = cur.fetchone()
 
         # save to file if found
-        if manifest:
-          with open("/dbt/old_manifest/mainfest.json", "w") as f:
-              f.write(json.dumps(manifest));
+        if manifest and len(mainfest) > 0:
+          with open("/dbt/old_manifest/manifest.json", "w") as f:
+              f.write(json.dumps(manifest[0]));
 
         # run dbt ls to make sure current manifest is generated
         subprocess.run(["dbt", "ls",  "--profiles-dir", ".dbt"])


### PR DESCRIPTION
…tinously

@njuguna-n and @lorerod what do you think about this:

This change addresses the issue of dropping views during the continuous update and the related issue of updating changed incremental tables https://github.com/medic/cht-pipeline/issues/78
dbt has a selector for changed models only. the complication is that it requires a manifest file to know what is changed. dataemon is already using the database to save metadata about the package, so this seems like a natural place to also add this manifest, although it is a bit messy since its a big json.

So, whenever the dbt container starts, it loads the last manifest from the db into the old_manifest directory
then, it generates the new manifest, and saves that back to the db
then it runs dbt using the "state:modified" selector, and the old manifest, to do a full refresh of anything has changed since the last run.
also runs using the "config.materialized:view" selector to make sure any views that have not changed but still need to be created are up to date.
During the the loop where it runs continuously, it excludes views and **only updates the incremental tables**

this will simplify the design of models; because the views are no longer dropped, **it removes the requirement for dashboards to only read from materialized tables**, and means the duration of the dbt run to update incremental tables only affects the incremental tables themselves.

if we can use views effectively, we can shift the strategy for what should be an incremental table and what should be a view to what dbt recommends; start with views, and only convert things to incremental tables when performance becomes a problem, or when downstream model require indexes. Having everything be incremental tables could also work but means that every model requires additional logic, can become out of date, and requires a lengthy full refresh when its changed.