### PR TITLE
Always use latest commit

### DIFF
--- a/dbt/dbt-run.py
+++ b/dbt/dbt-run.py
@@ -74,6 +74,6 @@ while True:
             with open("/dbt/packages.yml", "w") as f:
                 f.write(json.dumps(cur.fetchone()[0]))
 
-    subprocess.run(["dbt", "deps", "--profiles-dir", ".dbt", "--force"])
+    subprocess.run(["dbt", "deps", "--profiles-dir", ".dbt", "--upgrade"])
     subprocess.run(["dbt", "run",  "--profiles-dir", ".dbt"])
     time.sleep(int(os.getenv("DATAEMON_INTERVAL") or 5))

--- a/dbt/dbt-run.py
+++ b/dbt/dbt-run.py
@@ -74,6 +74,6 @@ while True:
             with open("/dbt/packages.yml", "w") as f:
                 f.write(json.dumps(cur.fetchone()[0]))
 
-    subprocess.run(["dbt", "deps", "--profiles-dir", ".dbt"])
+    subprocess.run(["dbt", "deps", "--profiles-dir", ".dbt", "--force"])
     subprocess.run(["dbt", "run",  "--profiles-dir", ".dbt"])
     time.sleep(int(os.getenv("DATAEMON_INTERVAL") or 5))


### PR DESCRIPTION
This forces DBT to use the latest commit. Otherwise new changes to models would necessitate restarting dbt in the container/pod where it's running