### PR TITLE
Update .env to work with local setup by default

### DIFF
--- a/env.template
+++ b/env.template
@@ -7,7 +7,7 @@ POSTGRES_PASSWORD=postgres
 POSTGRES_DB=data
 POSTGRES_SCHEMA=v1
 POSTGRES_TABLE=medic # for dbt use only
-POSTGRES_HOST=someip # Your postgres instance IP or endpoint in "prod".
+POSTGRES_HOST=postgres # Your postgres instance IP or endpoint in "prod".
 POSTGRES_PORT=5432
 
 # dbt


### PR DESCRIPTION
# Description

I [tried deploying](https://forum.communityhealthtoolkit.org/t/pointing-cht-sync-at-a-docker-helper-instance/3846) the local setup and got pretty close, but having a sane default for local setup for `POSTGRES_HOST` would be a big help.  We'll very likely need to change this value to something bespoke, so having a default value that works for [local setup](https://docs.communityhealthtoolkit.org/apps/guides/data/analytics/setup/) would be nice!

# Code review checklist
<!-- Remove or comment out any items that do not apply to this PR; in the remaining boxes, replace the [ ] with [x]. -->
- [ ] Readable: Concise, well named, follows the [style guide](https://docs.communityhealthtoolkit.org/contribute/code/style-guide/), documented if necessary.
- [ ] Documented: Configuration and user documentation on [cht-docs](https://github.com/medic/cht-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in the release notes.

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.