### PR TITLE
fix(#139): only rebuild tables and views on startup

### DIFF
--- a/dbt/dbt-run.py
+++ b/dbt/dbt-run.py
@@ -130,12 +130,15 @@ def update_models():
       "./old_manifest"])
 
 def run_incremental_models():
-  # update incremental models (and tables if there are any)
-  subprocess.run(["dbt", "run",  "--profiles-dir", ".dbt", "--exclude", "config.materialized:view"])
+  # update incremental models and materialized views
+  subprocess.run(["dbt", "run",  "--profiles-dir", ".dbt", "--exclude", "config.materialized:view", "--exclude", "config.materialized:table"])
 
 
 if __name__ == "__main__":
   setup()
+  update_models()
+  # run dbt once at startup to make sure tables and unmaterialized views are created
+  subprocess.run(["dbt", "run",  "--profiles-dir", ".dbt"])
   while True:
     update_models()
     run_incremental_models()


### PR DESCRIPTION
closes(#139)

this excludes tables (and views) from the continuous run. If the definition changes, they will be caught by the full-refresh but otherwise new data in the source won't be reflected.

Which may not be what is intended.
To solve the refresh issue, probably better to have them as materialized views.