### PR TITLE
fix: add initialize_couchdb container that creates the default DBs

### DIFF
--- a/docker-compose.couchdb.yml
+++ b/docker-compose.couchdb.yml
@@ -9,3 +9,11 @@ services:
     environment:
       - COUCHDB_USER=${COUCHDB_USER}
       - COUCHDB_PASSWORD=${COUCHDB_PASSWORD}
+  initialize_couchdb:
+    image: curlimages/curl
+    deploy:
+      restart_policy:
+        condition: on-failure
+    depends_on:
+      - couchdb
+    command: ["sh","-c","sleep 15 && curl -u ${COUCHDB_USER}:${COUCHDB_PASSWORD} -X PUT couchdb:5984/_users &&  curl -u ${COUCHDB_USER}:${COUCHDB_PASSWORD} -X PUT couchdb:5984/medic"]


### PR DESCRIPTION
# Description

Create `_users` and `medic` databases in the couchdb container to fix 404 error.

medic/cht-sync#148

# Code review checklist
<!-- Remove or comment out any items that do not apply to this PR; in the remaining boxes, replace the [ ] with [x]. -->
- [ ] Readable: Concise, well named, follows the [style guide](https://docs.communityhealthtoolkit.org/contribute/code/style-guide/), documented if necessary.
- [ ] Documented: Configuration and user documentation on [cht-docs](https://github.com/medic/cht-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in the release notes.

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.