### PR TITLE
fix(#151): failing build github action

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,9 +1,10 @@
 name: Build cht-sync containers
 
 on:
-  push:
-    branches:
-      - fix-docker-hub-ci-upload
+  workflow_run:
+    workflows: ["release"]
+    types:
+      - completed
 
 jobs:
   build:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,7 +27,11 @@ jobs:
               owner: context.repo.owner,
               repo: context.repo.repo,
             });
-            core.setOutput('result', latestRelease.tag_name);
+            if (!latestRelease || !latestRelease.tag_name) {
+              core.setFailed('Failed to get the latest release tag');
+            } else {
+              core.setOutput('result', latestRelease.tag_name);
+            }
 
       - name: Build and push couch2pg
         uses: docker/build-push-action@v4

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,7 +20,9 @@ jobs:
 
       - name: Get the latest release tag
         id: get_latest_release
-        run: echo ::set-output name=result::${GITHUB_REF#refs/tags/}
+        run: |
+          LATEST_TAG=$(curl -sL https://api.github.com/repos/medic/cht-sync/releases/latest | jq -r '.tag_name')
+          echo "RELEASE_TAG=$LATEST_TAG" >> $GITHUB_ENV
 
       - name: Build and push couch2pg
         uses: docker/build-push-action@v4
@@ -28,7 +30,7 @@ jobs:
           context: ./couch2pg
           file: ./couch2pg/Dockerfile
           push: true
-          tags: medicmobile/cht-sync-couch2pg:${{ steps.get_latest_release.outputs.result }}
+          tags: medicmobile/cht-sync-couch2pg:${{ steps.get_latest_release.outputs.RELEASE_TAG }}
 
       - name: Build and push dataemon
         uses: docker/build-push-action@v4
@@ -36,4 +38,4 @@ jobs:
           context: ./dbt
           file: ./dbt/Dockerfile
           push: true
-          tags: medicmobile/dataemon:${{ steps.get_latest_release.outputs.result }}
+          tags: medicmobile/dataemon:${{ steps.get_latest_release.outputs.RELEASE_TAG }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,8 +21,22 @@ jobs:
       - name: Get the latest release tag
         id: get_latest_release
         run: |
-          LATEST_TAG=$(curl -sL https://api.github.com/repos/medic/cht-sync/releases/latest | jq -r '.tag_name')
-          echo "RELEASE_TAG=$LATEST_TAG" >> $GITHUB_ENV
+          API_RESPONSE=$(curl -sL https://api.github.com/repos/${{ github.repository }}/releases/latest)
+          echo "API Response: $API_RESPONSE"
+          
+          if [ "$(echo "$API_RESPONSE" | jq -r .message)" = "Not Found" ]; then
+            echo "No releases found. Using 'latest' as the tag."
+            LATEST_TAG="latest"
+          else
+            LATEST_TAG=$(echo "$API_RESPONSE" | jq -r .tag_name)
+            if [ -z "$LATEST_TAG" ] || [ "$LATEST_TAG" = "null" ]; then
+              echo "Failed to extract tag. Using 'latest' as the tag."
+              LATEST_TAG="latest"
+            fi
+          fi
+          
+          echo "Extracted tag: $LATEST_TAG"
+          echo "RELEASE_TAG=$LATEST_TAG" >> $GITHUB_OUTPUT
 
       - name: Build and push couch2pg
         uses: docker/build-push-action@v4

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,20 +22,12 @@ jobs:
         id: get_latest_release
         run: |
           API_RESPONSE=$(curl -sL https://api.github.com/repos/${{ github.repository }}/releases/latest)
-          echo "API Response: $API_RESPONSE"
           
-          if [ "$(echo "$API_RESPONSE" | jq -r .message)" = "Not Found" ]; then
-            echo "No releases found. Using 'latest' as the tag."
+          LATEST_TAG=$(echo "$API_RESPONSE" | jq -r .tag_name)
+          if [ -z "$LATEST_TAG" ] || [ "$LATEST_TAG" = "null" ]; then
             LATEST_TAG="latest"
-          else
-            LATEST_TAG=$(echo "$API_RESPONSE" | jq -r .tag_name)
-            if [ -z "$LATEST_TAG" ] || [ "$LATEST_TAG" = "null" ]; then
-              echo "Failed to extract tag. Using 'latest' as the tag."
-              LATEST_TAG="latest"
-            fi
           fi
           
-          echo "Extracted tag: $LATEST_TAG"
           echo "RELEASE_TAG=$LATEST_TAG" >> $GITHUB_OUTPUT
 
       - name: Build and push couch2pg

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,10 +1,9 @@
 name: Build cht-sync containers
 
 on:
-  workflow_run:
-    workflows: ["release"]
-    types:
-      - completed
+  push:
+    branches:
+      - fix-docker-hub-ci-upload
 
 jobs:
   build:
@@ -24,11 +23,11 @@ jobs:
         uses: actions/github-script@v6
         with:
           script: |
-            const latestRelease = await github.repos.getLatestRelease({
+            const { data: latestRelease } = await github.rest.repos.getLatestRelease({
               owner: context.repo.owner,
               repo: context.repo.repo,
             });
-            return latestRelease.data.tag_name;
+            core.setOutput('result', latestRelease.tag_name);
 
       - name: Build and push couch2pg
         uses: docker/build-push-action@v4

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,7 +37,9 @@ jobs:
           context: ./couch2pg
           file: ./couch2pg/Dockerfile
           push: true
-          tags: medicmobile/cht-sync-couch2pg:${{ steps.get_latest_release.outputs.RELEASE_TAG }}
+          tags: |
+            medicmobile/cht-sync-couch2pg:${{ steps.get_latest_release.outputs.RELEASE_TAG }}
+            medicmobile/cht-sync-couch2pg:latest
 
       - name: Build and push dataemon
         uses: docker/build-push-action@v4
@@ -45,4 +47,6 @@ jobs:
           context: ./dbt
           file: ./dbt/Dockerfile
           push: true
-          tags: medicmobile/dataemon:${{ steps.get_latest_release.outputs.RELEASE_TAG }}
+          tags: |
+            medicmobile/dataemon:${{ steps.get_latest_release.outputs.RELEASE_TAG }}
+            medicmobile/dataemon:latest

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,18 +20,7 @@ jobs:
 
       - name: Get the latest release tag
         id: get_latest_release
-        uses: actions/github-script@v6
-        with:
-          script: |
-            const { data: latestRelease } = await github.rest.repos.getLatestRelease({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-            });
-            if (!latestRelease || !latestRelease.tag_name) {
-              core.setFailed('Failed to get the latest release tag');
-            } else {
-              core.setOutput('result', latestRelease.tag_name);
-            }
+        run: echo ::set-output name=result::${GITHUB_REF#refs/tags/}
 
       - name: Build and push couch2pg
         uses: docker/build-push-action@v4


### PR DESCRIPTION
# Description

Fixes the failing `build` github action

closes medic/cht-sync#151

# Code review checklist
<!-- Remove or comment out any items that do not apply to this PR; in the remaining boxes, replace the [ ] with [x]. -->
- [ ] Readable: Concise, well named, follows the [style guide](https://docs.communityhealthtoolkit.org/contribute/code/style-guide/), documented if necessary.
- [ ] Documented: Configuration and user documentation on [cht-docs](https://github.com/medic/cht-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in the release notes.

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.