### PR TITLE
fix(#145): adds volume mount for postgres

### DIFF
--- a/deploy/cht_sync/templates/postgres-pvc.yaml
+++ b/deploy/cht_sync/templates/postgres-pvc.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.postgres.enabled }}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: postgres-pvc
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: {{ .Values.postgres.storageSize | default "1Gi" }}
+{{- end }}

--- a/deploy/cht_sync/templates/postgres.yaml
+++ b/deploy/cht_sync/templates/postgres.yaml
@@ -33,15 +33,15 @@ spec:
               value: {{ .Values.postgres.password }}
             - name: POSTGRES_DB
               value: {{ .Values.postgres.db }}
+            - name: PGDATA
+              value: "/var/lib/postgresql/data/pgdata"
           ports:
             - containerPort: {{ .Values.postgres.port | default "5432" }}
-
-  volumeClaimTemplates:
-    - metadata:
-        name: postgres-data
-      spec:
-        accessModes: [ "ReadWriteOnce" ]
-        resources:
-          requests:
-            storage: {{ .Values.postgres.storageSize | default "1Gi" }}
+          volumeMounts:
+            - name: postgres-data
+              mountPath: /var/lib/postgresql/data
+      volumes:
+        - name: postgres-data
+          persistentVolumeClaim:
+            claimName: postgres-pvc
 {{- end }}


### PR DESCRIPTION
adds a volumeMount to postgres. for postgres hosted inside the kubernetes cluster, this is necessarry for the database to use the persistent volume claim.

#145 