### PR TITLE
feat(#142): adds reusable github action that creates backup of superset dashboard export

### DIFF
--- a/.github/actions/superset-backup/README.md
+++ b/.github/actions/superset-backup/README.md
@@ -1,0 +1,34 @@
+# superset-backup Shared GitHub action
+
+
+The `superset-backup` is a parameterised reusable GitHub action that exports all dashboard data from a superset instance and saves it as a zip file in the repository that uses the action.
+
+This action uses the Superset API to authenticate and export dashboard config.
+Backups are saved in a `/superset/backups` folder, each backup being a zip file named based on the date and time when the backup was generated. eg. `/superset/backups/20240918082215.zip`. 
+The format of the export is controlled by superset and no additional transformation is done within this action. 
+
+Requires the following variables: 
+- `gh_token`: GitHub token that has access to push to the main branch of the repository.
+- `superset_link`: Http link to the superset instance. Eg: https://superset.app.com
+- `superset_user`: Superset username that has access to the superset API
+- `superset_password`: Password of the Superset user
+
+## Example GitHub Step
+
+```
+name: Example GitHub Workflow yml
+
+on: ['push']
+
+jobs:
+  deployment:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Make backup
+        uses: 'dianabarsan/superset-backup/.github/actions/superset-backup@main'
+        with:
+          gh_token: ${{ secrets.GH_TOKEN }}
+          superset_link: ${{ secrets.SUPERSET_LINK }}
+          superset_user: ${{ secrets.SUPERSET_USER }}
+          superset_password: ${{ secrets.SUPERSET_PASSWORD }}
+```

--- a/.github/actions/superset-backup/README.md
+++ b/.github/actions/superset-backup/README.md
@@ -1,11 +1,11 @@
 # superset-backup Shared GitHub action
 
 
-The `superset-backup` is a parameterised reusable GitHub action that exports all dashboard data from a superset instance and saves it as a zip file in the repository that uses the action.
+The `superset-backup` is a parameterised reusable GitHub action that exports dashboard config from a Superset instance and saves it as a zip file in the repository that uses the action.
 
 This action uses the Superset API to authenticate and export dashboard config.
-Backups are saved in a `/superset/backups` folder, each backup being a zip file named based on the date and time when the backup was generated. eg. `/superset/backups/20240918082215.zip`. 
-The format of the export is controlled by superset and no additional transformation is done within this action. 
+Backups are saved in `/superset/backups` folder, as zip files named based on the date and time when the backups ware generated. eg. `/superset/backups/20240918082215.zip`. 
+The format of the export is controlled by Superset and no additional transformation is done within this action. 
 
 Requires the following variables: 
 - `gh_token`: GitHub token that has access to push to the main branch of the repository.
@@ -25,7 +25,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Make backup
-        uses: 'dianabarsan/superset-backup/.github/actions/superset-backup@main'
+        uses: 'medic/cht-sync/.github/actions/superset-backup@main'
         with:
           gh_token: ${{ secrets.GH_TOKEN }}
           superset_link: ${{ secrets.SUPERSET_LINK }}

--- a/.github/actions/superset-backup/action.yml
+++ b/.github/actions/superset-backup/action.yml
@@ -1,0 +1,36 @@
+name: 'superset-backup'
+description: 'Download and save Superset dashboard export in a GH repository'
+inputs:
+  gh_token:
+    description: 'The token to use to access the GitHub API'
+    required: true
+  superset_link:
+    description: 'The link to the superset server'
+    required: true
+  superset_user:
+    description: 'The user to use to access the Superset API'
+    required: true
+  superset_password:
+    description: 'The password to use to access the Superset API'
+    required: true
+
+runs:
+  using: 'composite'
+  steps:
+    - uses: actions/checkout@master
+    - name: Download superset export
+      shell: bash
+      run: |
+        NOW=$(date +%Y%m%d%H%M%S)
+        mkdir -p ./superset/backups        
+        LOGIN=$(curl -X POST -d '{"username":"${{ inputs.superset_user }}","password":"${{ inputs.superset_password }}","provider":"db"}' -H "Content-Type: application/json" ${{ inputs.superset_link }}/api/v1/security/login)
+        ACCESS_TOKEN=$(echo $LOGIN | sed "s/{.*\"access_token\":\"\([^\"]*\).*}/\1/g") 
+        CSRF=$(curl "${{ inputs.superset_link }}/api/v1/security/csrf_token/" -H "Authorization: Bearer $ACCESS_TOKEN") 
+        CSRF_TOKEN=$(echo $CSRF | sed "s/{.*\"result\":\"\([^\"]*\).*}/\1/g") 
+        curl -X GET -0 ${{ inputs.superset_link }}/api/v1/assets/export/ -H "Authorization: Bearer $ACCESS_TOKEN" -H "X-CSRFToken: $CSRF_TOKEN" -o ./superset/backups/$NOW.zip
+    - name: Upload superset export
+      uses: actions-js/push@master
+      with:
+        github_token: ${{ inputs.gh_token }}
+        message: 'chore: autobackup'
+

--- a/.github/actions/superset-backup/action.yml
+++ b/.github/actions/superset-backup/action.yml
@@ -32,5 +32,5 @@ runs:
       uses: actions-js/push@master
       with:
         github_token: ${{ inputs.gh_token }}
-        message: 'chore: autobackup'
+        message: 'chore: Superset autobackup'
 


### PR DESCRIPTION
# Description

This reusable GH action will store a Superset export within the repo that triggers the action. 
Can be further parametrized if desired, but for now:
- only supports saving in the current repo
- saves on hardcoded path

#142

# Code review checklist
<!-- Remove or comment out any items that do not apply to this PR; in the remaining boxes, replace the [ ] with [x]. -->
- [ ] Readable: Concise, well named, follows the [style guide](https://docs.communityhealthtoolkit.org/contribute/code/style-guide/), documented if necessary.
- [ ] Documented: Configuration and user documentation on [cht-docs](https://github.com/medic/cht-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in the release notes.

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.