### PR TITLE
chore: manually bump package json version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cht-sync",
-  "version": "1.0.0",
+  "version": "1.1.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "cht-sync",
-      "version": "1.0.0",
+      "version": "1.1.1",
       "hasInstallScript": true,
       "license": "ISC",
       "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cht-sync",
-  "version": "1.0.0",
+  "version": "1.1.1",
   "description": "",
   "main": "",
   "scripts": {


### PR DESCRIPTION
# Description

As the automatic update of `package.json` upon release doesn't work (#155), manually update the version to the latest. The release is already done, so this is not very useful until we fix #155, but at least it keeps the `main` branch up to date. 

# Code review checklist
<!-- Remove or comment out any items that do not apply to this PR; in the remaining boxes, replace the [ ] with [x]. -->
- [ ] Readable: Concise, well named, follows the [style guide](https://docs.communityhealthtoolkit.org/contribute/code/style-guide/), documented if necessary.
- [ ] Documented: Configuration and user documentation on [cht-docs](https://github.com/medic/cht-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in the release notes.

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.