### PR TITLE
fix(#155): use semantic release npm module

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ jobs:
         with:
           node-version: 20.x
       - name: Install Semantic Release and plugins
-        run: npm install -g semantic-release @semantic-release/git @semantic-release/changelog @semantic-release/github @semantic-release/commit-analyzer @semantic-release/release-notes-generator
+        run: npm install -g semantic-release @semantic-release/git @semantic-release/changelog @semantic-release/github @semantic-release/commit-analyzer @semantic-release/release-notes-generator @semantic-release/npm
       - name: Release
         env:
           GITHUB_TOKEN: ${{ secrets.GH_ADMIN_TOKEN }}

--- a/.releaserc
+++ b/.releaserc
@@ -3,6 +3,7 @@
   "plugins": [
     "@semantic-release/commit-analyzer",
     "@semantic-release/release-notes-generator",
+    "@semantic-release/npm",
     "@semantic-release/github",
     [
       "@semantic-release/changelog",


### PR DESCRIPTION
# Description

(hopefully) closes #155 

Per [this conversation](https://github.com/semantic-release/semantic-release/issues/1593#issuecomment-656871587), the `npm` module is responsible for editing the `package.json`, and is needed in the configuration. 

[Additional resources on the topic.](https://semantic-release.gitbook.io/semantic-release/support/faq) 

# Code review checklist
<!-- Remove or comment out any items that do not apply to this PR; in the remaining boxes, replace the [ ] with [x]. -->
- [ ] Readable: Concise, well named, follows the [style guide](https://docs.communityhealthtoolkit.org/contribute/code/style-guide/), documented if necessary.
- [ ] Documented: Configuration and user documentation on [cht-docs](https://github.com/medic/cht-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in the release notes.

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.