### PR TITLE
fix: pin python version to 3.12

### DIFF
--- a/dbt/Dockerfile
+++ b/dbt/Dockerfile
@@ -1,10 +1,10 @@
-FROM python:3 AS testing
+FROM python:3.12 AS testing
 
 RUN pip install flake8
 
 RUN flake8 dbt-run.py
 
-FROM python:3 AS release
+FROM python:3.12 AS release
 
 RUN pip install --upgrade cffi \
     && pip install cryptography~=3.4 \


### PR DESCRIPTION
# Description


closes medic/cht-sync#163
# Code review checklist
<!-- Remove or comment out any items that do not apply to this PR; in the remaining boxes, replace the [ ] with [x]. -->
- [ ] Readable: Concise, well named, follows the [style guide](https://docs.communityhealthtoolkit.org/contribute/code/style-guide/), documented if necessary.
- [ ] Documented: Configuration and user documentation on [cht-docs](https://github.com/medic/cht-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in the release notes.

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.