### PR TITLE
chore(na): rename compose project from pipeline to cht-sync

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,3 +1,4 @@
+name: ${COMPOSE_PROJECT_NAME:-cht-sync}
 services:
   couch2pg:
     build: ./couch2pg/

--- a/env.template
+++ b/env.template
@@ -1,6 +1,3 @@
-# (Optional) project wide
-COMPOSE_PROJECT_NAME=pipeline
-
 # postgresql
 POSTGRES_USER=postgres
 POSTGRES_PASSWORD=postgres
@@ -21,3 +18,6 @@ COUCHDB_DBS="medic" # space separated list of databases you want to sync e.g "me
 COUCHDB_HOST=couchdb
 COUCHDB_PORT=5984
 COUCHDB_SECURE=false
+
+# (Optional) project wide
+#COMPOSE_PROJECT_NAME=cht-sync


### PR DESCRIPTION
# Description

Our docker compose project is named `pipeline` which we don't reference anymore.  This also causes containers to be named `pipeline-pgadmin` etc. which folks may not know is actually `cht-sync` related:

```
docker ps --format "table {{.Status}}\t{{.Names}}"        
STATUS                         NAMES
Restarting (1) 4 seconds ago   pipeline-couch2pg-1
Up 21 seconds                  pipeline-pgadmin-1
Up 21 seconds                  pipeline-dbt-1
Up 19 seconds                  pipeline-postgres-1
```

I think we should comment out the `.env` project name and add a sane default to the main compose file.


# Code review checklist
<!-- Remove or comment out any items that do not apply to this PR; in the remaining boxes, replace the [ ] with [x]. -->
- [X] Readable: Concise, well named, follows the [style guide](https://docs.communityhealthtoolkit.org/contribute/code/style-guide/), documented if necessary.
- [X] Documented: Configuration and user documentation on [cht-docs](https://github.com/medic/cht-docs/)
- [X] Tested: Unit and/or e2e where appropriate
- [X] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in the release notes.

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.
