### PR TITLE
fix(#193): only create indexes if table does not exist

### DIFF
--- a/couch2pg/src/setup.js
+++ b/couch2pg/src/setup.js
@@ -18,11 +18,11 @@ CREATE TABLE IF NOT EXISTS ${db.postgresProgressTable} (
 );`;
 
 const createDeleteIndex = `
-CREATE INDEX IF NOT EXISTS _deleted ON ${db.postgresTable}(_deleted);
+CREATE INDEX CONCURRENTLY IF NOT EXISTS _deleted ON ${db.postgresTable}(_deleted);
 `;
 
 const createTimestampIndex = `
-CREATE INDEX IF NOT EXISTS saved_timestamp ON ${db.postgresTable}(saved_timestamp);
+CREATE INDEX CONCURRENTLY IF NOT EXISTS saved_timestamp ON ${db.postgresTable}(saved_timestamp);
 `;
 
 export const createDatabase = async () => {

--- a/couch2pg/src/setup.js
+++ b/couch2pg/src/setup.js
@@ -1,7 +1,6 @@
 import * as db from './db.js';
 
 const createSchema = `CREATE SCHEMA IF NOT EXISTS ${db.postgresSchema}`;
-
 const createTable = `
 CREATE TABLE IF NOT EXISTS ${db.postgresTable} (
   saved_timestamp TIMESTAMP,
@@ -26,37 +25,12 @@ const createTimestampIndex = `
 CREATE INDEX IF NOT EXISTS saved_timestamp ON ${db.postgresTable}(saved_timestamp);
 `;
 
-
-const checkTableExists = async (client) => {
-  const tableExists = `SELECT 1 FROM ${db.postgresTable} LIMIT 1;`;
-
-  try {
-    await client.query(tableExists);
-    return true;
-  } catch (error) {
-    // "Undefined table" error code in PostgreSQL
-    if (error.code === '42P01') {
-      return false;
-    }
-    throw error;
-  }
-};
-
 export const createDatabase = async () => {
   const client = await db.getPgClient();
   await client.query(createSchema);
-
-  // create the table and indexes if they don't exist
-  // note that `CREATE INDEX IF NOT EXISTS` acquires a lock
-  // even if the index exists, so cannot rely on it here,
-  // have to actually check if the table exists in a separate query
-  const tableExists = await checkTableExists(client);
-  if (!tableExists) {
-    await client.query(createTable);
-    await client.query(createDeleteIndex);
-    await client.query(createTimestampIndex);
-  }
-
+  await client.query(createTable);
+  await client.query(createDeleteIndex);
+  await client.query(createTimestampIndex);
   await client.query(createProgressTable);
   await client.end();
 };

--- a/couch2pg/src/setup.js
+++ b/couch2pg/src/setup.js
@@ -1,6 +1,7 @@
 import * as db from './db.js';
 
 const createSchema = `CREATE SCHEMA IF NOT EXISTS ${db.postgresSchema}`;
+
 const createTable = `
 CREATE TABLE IF NOT EXISTS ${db.postgresTable} (
   saved_timestamp TIMESTAMP,
@@ -25,12 +26,37 @@ const createTimestampIndex = `
 CREATE INDEX IF NOT EXISTS saved_timestamp ON ${db.postgresTable}(saved_timestamp);
 `;
 
+
+const checkTableExists = async (client) => {
+  const tableExists = `SELECT 1 FROM ${db.postgresTable} LIMIT 1;`;
+
+  try {
+    await client.query(tableExists);
+    return true;
+  } catch (error) {
+    // "Undefined table" error code in PostgreSQL
+    if (error.code === '42P01') {
+      return false;
+    }
+    throw error;
+  }
+};
+
 export const createDatabase = async () => {
   const client = await db.getPgClient();
   await client.query(createSchema);
-  await client.query(createTable);
-  await client.query(createDeleteIndex);
-  await client.query(createTimestampIndex);
+
+  // create the table and indexes if they don't exist
+  // note that `CREATE INDEX IF NOT EXISTS` acquires a lock
+  // even if the index exists, so cannot rely on it here,
+  // have to actually check if the table exists in a separate query
+  const tableExists = await checkTableExists(client);
+  if (!tableExists) {
+    await client.query(createTable);
+    await client.query(createDeleteIndex);
+    await client.query(createTimestampIndex);
+  }
+
   await client.query(createProgressTable);
   await client.end();
 };

--- a/couch2pg/tests/unit/setup.spec.js
+++ b/couch2pg/tests/unit/setup.spec.js
@@ -43,10 +43,10 @@ CREATE TABLE IF NOT EXISTS v1.whatever (
   doc jsonb
 )`]);
       expect(pgClient.query.args[2]).to.deep.equal([`
-CREATE INDEX IF NOT EXISTS _deleted ON v1.whatever(_deleted);
+CREATE INDEX CONCURRENTLY IF NOT EXISTS _deleted ON v1.whatever(_deleted);
 `]);
       expect(pgClient.query.args[3]).to.deep.equal([`
-CREATE INDEX IF NOT EXISTS saved_timestamp ON v1.whatever(saved_timestamp);
+CREATE INDEX CONCURRENTLY IF NOT EXISTS saved_timestamp ON v1.whatever(saved_timestamp);
 `]);
       expect(pgClient.query.args[4]).to.deep.equal([`
 CREATE TABLE IF NOT EXISTS v1.couchdb_progress (

--- a/couch2pg/tests/unit/setup.spec.js
+++ b/couch2pg/tests/unit/setup.spec.js
@@ -13,6 +13,10 @@ describe('setup', () => {
       end: sinon.stub(),
     };
 
+    pgClient.query.withArgs(`SELECT 1 FROM v1.whatever LIMIT 1;`).rejects({
+      code: '42P01',
+    });
+
     db = {
       getPgClient: sinon.stub().returns(pgClient),
       postgresSchema: 'v1',
@@ -32,23 +36,24 @@ describe('setup', () => {
       await setup.createDatabase();
 
       expect(db.getPgClient.calledOnce).to.equal(true);
-      expect(pgClient.query.callCount).to.equal(5);
+      expect(pgClient.query.callCount).to.equal(6);
       expect(pgClient.end.calledOnce).to.equal(true);
       expect(pgClient.query.args[0]).to.deep.equal(['CREATE SCHEMA IF NOT EXISTS v1']);
-      expect(pgClient.query.args[1]).to.deep.equal([ `
+      expect(pgClient.query.args[1]).to.deep.equal([`SELECT 1 FROM v1.whatever LIMIT 1;`]);
+      expect(pgClient.query.args[2]).to.deep.equal([ `
 CREATE TABLE IF NOT EXISTS v1.whatever (
   saved_timestamp TIMESTAMP,
   _id VARCHAR PRIMARY KEY,
   _deleted BOOLEAN,
   doc jsonb
 )`]);
-      expect(pgClient.query.args[2]).to.deep.equal([`
+      expect(pgClient.query.args[3]).to.deep.equal([`
 CREATE INDEX IF NOT EXISTS _deleted ON v1.whatever(_deleted);
 `]);
-      expect(pgClient.query.args[3]).to.deep.equal([`
+      expect(pgClient.query.args[4]).to.deep.equal([`
 CREATE INDEX IF NOT EXISTS saved_timestamp ON v1.whatever(saved_timestamp);
 `]);
-      expect(pgClient.query.args[4]).to.deep.equal([`
+      expect(pgClient.query.args[5]).to.deep.equal([`
 CREATE TABLE IF NOT EXISTS v1.couchdb_progress (
   seq varchar,
   pending integer,

--- a/couch2pg/tests/unit/setup.spec.js
+++ b/couch2pg/tests/unit/setup.spec.js
@@ -13,10 +13,6 @@ describe('setup', () => {
       end: sinon.stub(),
     };
 
-    pgClient.query.withArgs(`SELECT 1 FROM v1.whatever LIMIT 1;`).rejects({
-      code: '42P01',
-    });
-
     db = {
       getPgClient: sinon.stub().returns(pgClient),
       postgresSchema: 'v1',
@@ -36,24 +32,23 @@ describe('setup', () => {
       await setup.createDatabase();
 
       expect(db.getPgClient.calledOnce).to.equal(true);
-      expect(pgClient.query.callCount).to.equal(6);
+      expect(pgClient.query.callCount).to.equal(5);
       expect(pgClient.end.calledOnce).to.equal(true);
       expect(pgClient.query.args[0]).to.deep.equal(['CREATE SCHEMA IF NOT EXISTS v1']);
-      expect(pgClient.query.args[1]).to.deep.equal([`SELECT 1 FROM v1.whatever LIMIT 1;`]);
-      expect(pgClient.query.args[2]).to.deep.equal([ `
+      expect(pgClient.query.args[1]).to.deep.equal([ `
 CREATE TABLE IF NOT EXISTS v1.whatever (
   saved_timestamp TIMESTAMP,
   _id VARCHAR PRIMARY KEY,
   _deleted BOOLEAN,
   doc jsonb
 )`]);
-      expect(pgClient.query.args[3]).to.deep.equal([`
+      expect(pgClient.query.args[2]).to.deep.equal([`
 CREATE INDEX IF NOT EXISTS _deleted ON v1.whatever(_deleted);
 `]);
-      expect(pgClient.query.args[4]).to.deep.equal([`
+      expect(pgClient.query.args[3]).to.deep.equal([`
 CREATE INDEX IF NOT EXISTS saved_timestamp ON v1.whatever(saved_timestamp);
 `]);
-      expect(pgClient.query.args[5]).to.deep.equal([`
+      expect(pgClient.query.args[4]).to.deep.equal([`
 CREATE TABLE IF NOT EXISTS v1.couchdb_progress (
   seq varchar,
   pending integer,


### PR DESCRIPTION
closes #193 

check if table exists in a separate query before creating indexes