### PR TITLE
fix(#189): add dbt thread count to helm

### DIFF
--- a/deploy/cht_sync/templates/dbt.yaml
+++ b/deploy/cht_sync/templates/dbt.yaml
@@ -40,5 +40,5 @@ spec:
             - name: CHT_PIPELINE_BRANCH_URL
               value: {{ .Values.cht_pipeline_branch_url }}
             - name: DBT_THREAD_COUNT
-              value: {{ .Values.dbt_thread_count | default "1" }}
+              value: {{ .Values.dbt_thread_count | default "1" | quote }}
 

--- a/deploy/cht_sync/templates/dbt.yaml
+++ b/deploy/cht_sync/templates/dbt.yaml
@@ -39,4 +39,6 @@ spec:
               value: {{ .Values.postgres.schema }}
             - name: CHT_PIPELINE_BRANCH_URL
               value: {{ .Values.cht_pipeline_branch_url }}
+            - name: DBT_THREAD_COUNT
+              value: {{ .Values.dbt_thread_count | default "1" }}
 

--- a/deploy/cht_sync/values.yaml.template
+++ b/deploy/cht_sync/values.yaml.template
@@ -10,7 +10,7 @@ postgres:
   port: 5432 # if postgres is outside the cluster
 
 cht_pipeline_branch_url: "https://github.com/medic/cht-pipeline.git#main"
-DBT_THREAD_COUNT: 1
+dbt_thread_count: 1
 
 # values shared by all couchdb instances
 # can be omitted if couchdb instances do not share any values


### PR DESCRIPTION
adding dbt_thread_count env var to the helm template; without setting a default for the DBT_THREAD_COUNT variable and including it in the helm template, dbt fails with message `Env var required but not provided: 'DBT_THREAD_COUNT'`